### PR TITLE
Refactor: Add support for .NET programs

### DIFF
--- a/src/main/java/com/test/program_validation/initial/controller/SubmissionsController.java
+++ b/src/main/java/com/test/program_validation/initial/controller/SubmissionsController.java
@@ -4,6 +4,8 @@ import com.test.program_validation.initial.models.PubSubPayload;
 import com.test.program_validation.initial.utils.DockerController;
 import com.test.program_validation.initial.utils.UnzipSubmission;
 import org.springframework.web.bind.annotation.*;
+import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import java.util.Base64;
 
@@ -16,10 +18,39 @@ public class SubmissionsController {
         try {
             byte[] zipBytes = Base64.getDecoder().decode(payload.message.data);
             UnzipSubmission.saveZipToDisk(zipBytes);
+
             System.out.println(":white_check_mark: Received and saved ZIP from message: " + payload.message.messageId);
-            boolean isBuilt = DockerController.buildDockerImage("dynamic_test", "/Users/monoid/Documents/GitHub/dynamic-analysis-service/src/main/java/com/test/program_validation/initial/utils");
+
+            String courseCode = payload.message.courseCode;
+
+            // Get absolute path to the utils directory
+            Path projectRoot = Paths.get("").toAbsolutePath();
+            Path utilsPath = projectRoot.resolve("src/main/java/com/test/program_validation/initial/utils");
+
+            // Decide which Docker image to build based on the courseCode
+            String imageName;
+            String dockerfileName = switch (courseCode) {
+                case "18656" -> {
+                    imageName = "dotnet_image";
+                    yield "dotnet.Docker";
+                }
+                case "18664" -> {
+                    imageName = "java_image";
+                    yield "java.Docker";
+                }
+                default -> throw new IllegalArgumentException("Unsupported course code: " + courseCode);
+            };
+
+            Path dockerfilePath = utilsPath.resolve(dockerfileName);
+
+            // Build Docker image using the correct Dockerfile
+            boolean isBuilt = DockerController.buildDockerImage(
+                    imageName,
+                    dockerfilePath.toString()
+            );
+
             if (isBuilt) {
-                DockerController.runContainer("dynamic_test");
+                DockerController.runContainer(imageName);
             }
             else {
                 throw new RuntimeException("Unable to build the docker container");

--- a/src/main/java/com/test/program_validation/initial/models/PubSubMessage.java
+++ b/src/main/java/com/test/program_validation/initial/models/PubSubMessage.java
@@ -7,4 +7,5 @@ public class PubSubMessage {
     public Map<String, String> attributes;
     public String messageId;
     public String publishTime;
+    public String courseCode;
 }

--- a/src/main/java/com/test/program_validation/initial/utils/UnzipSubmission.java
+++ b/src/main/java/com/test/program_validation/initial/utils/UnzipSubmission.java
@@ -4,12 +4,16 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 public class UnzipSubmission {
     public static void saveZipToDisk(byte[] zipBytes) throws IOException {
-        String OUTPUT_DIR = "/Users/monoid/Documents/GitHub/dynamic-analysis-service/src/main/java/com/test/program_validation/initial/utils/unzip_files";
+        Path projectRoot = Paths.get("").toAbsolutePath(); // Gets the working directory at runtime
+        Path utilsPath = projectRoot.resolve("src/main/java/com/test/program_validation/initial/utils/unzip_files");
+        String OUTPUT_DIR = utilsPath.toString();
         File outputDir = new File(OUTPUT_DIR);
         if (!outputDir.exists()) outputDir.mkdirs();
         try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {

--- a/src/main/java/com/test/program_validation/initial/utils/dotnet.Dockerfile
+++ b/src/main/java/com/test/program_validation/initial/utils/dotnet.Dockerfile
@@ -1,0 +1,54 @@
+# Build-time argument for .NET SDK. Default is 8.0
+ARG SDK_VERSION=8.0
+
+# Base image of .NET SDK version
+FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION}
+
+# Install tools
+RUN apt-get update && \
+    apt-get install -y wget unzip xmlstarlet && \
+    apt-get install -y zip curl tar gzip iputils-ping && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Python3
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set gcloud environment variables
+ENV GCLOUD_VERSION=456.0.0
+ENV GCLOUD_FILE=google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz
+
+# Download and extract gcloud CLI
+RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILE}
+RUN tar -xzvf ${GCLOUD_FILE} && \
+    google-cloud-sdk/install.sh
+
+# Add to PATH
+ENV PATH="/google-cloud-sdk/bin:${PATH}"
+
+# Application setup
+WORKDIR /DynamicAnalysis
+COPY unzip_files .
+
+COPY dotnet_clean_test.sh .
+RUN chmod +x ./dotnet_clean_test.sh
+
+COPY zip-and-publish-nunit.py .
+RUN chmod +x ./zip_and_publish_nunit.py
+
+# TODO: REMOVE CREDENTIALS
+COPY gradiator-x-454207-6e09134229e4.json .
+RUN chmod +r ./gradiator-x-454207-6e09134229e4.json
+
+ENV GOOGLE_APPLICATION_CREDENTIALS=./gradiator-x-454207-6e09134229e4.json
+
+# Authenticate with service account
+RUN gcloud auth activate-service-account --key-file=./gradiator-x-454207-6e09134229e4.json && \
+    gcloud config set project gradiator-x-454207
+
+CMD ["/bin/sh", "-c", \
+  "./dotnet_clean_test.sh && \
+  python3 ./zip_and_publish_nunit.py"]

--- a/src/main/java/com/test/program_validation/initial/utils/dotnet_clean_test.sh
+++ b/src/main/java/com/test/program_validation/initial/utils/dotnet_clean_test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Find the main project file
+SOLUTION_FILE=$(find . -name "*.sln" | head -1)
+echo "Using project file: $SOLUTION_FILE"
+dotnet clean "$SOLUTION_FILE" && dotnet test "$SOLUTION_FILE" --logger "trx;LogFileName=testResults.trx"

--- a/src/main/java/com/test/program_validation/initial/utils/java.Dockerfile
+++ b/src/main/java/com/test/program_validation/initial/utils/java.Dockerfile
@@ -49,12 +49,10 @@ COPY build.gradle .
 COPY settings.gradle .
 COPY unzip_files ./src
 
-COPY zip-and-publish.sh .
-RUN chmod +x ./zip-and-publish.sh
+COPY zip_and_publish_junit.py .
+RUN chmod +x ./zip_and_publish_junit.py
 
-COPY zip_and_publish.py .
-RUN chmod +x ./zip_and_publish.py
-
+# TODO: REMOVE CREDENTIALS
 COPY gradiator-x-454207-6e09134229e4.json .
 RUN chmod +r ./gradiator-x-454207-6e09134229e4.json
 

--- a/src/main/java/com/test/program_validation/initial/utils/zip_and_publish_junit.py
+++ b/src/main/java/com/test/program_validation/initial/utils/zip_and_publish_junit.py
@@ -4,7 +4,7 @@ import base64
 from google.cloud import pubsub_v1
 # ---------- CONFIG ----------
 FOLDER_TO_ZIP = "src/build/reports"
-ZIP_NAME = "test-results.zip"
+ZIP_NAME = "test-results-junit.zip"
 PROJECT_ID = "gradiator-x-454207"
 TOPIC_ID = "dynamic-analysis-result"
 # ----------------------------

--- a/src/main/java/com/test/program_validation/initial/utils/zip_and_publish_nunit.py
+++ b/src/main/java/com/test/program_validation/initial/utils/zip_and_publish_nunit.py
@@ -1,0 +1,31 @@
+import os
+import zipfile
+import base64
+from google.cloud import pubsub_v1
+# ---------- CONFIG ----------
+FOLDER_TO_ZIP = "/DynamicAnalysis/Test/TestResults/testResults.trx"
+ZIP_NAME = "nunit-test-results.zip"
+PROJECT_ID = "gradiator-x-454207"
+TOPIC_ID = "dynamic-analysis-result"
+# ----------------------------
+def zip_folder(folder_path, zip_path):
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+        for root, _, files in os.walk(folder_path):
+            for file in files:
+                full_path = os.path.join(root, file)
+                rel_path = os.path.relpath(full_path, start=folder_path)
+                zipf.write(full_path, arcname=rel_path)
+    print(f":white_check_mark: Zipped folder {folder_path} -> {zip_path}")
+def publish_base64_zip(zip_path, project_id, topic_id):
+    publisher = pubsub_v1.PublisherClient()
+    topic_path = publisher.topic_path(project_id, topic_id)
+    with open(zip_path, "rb") as f:
+        zip_data = f.read()
+    # Base64 encode the zip
+    base64_zip = base64.b64encode(zip_data).decode("utf-8")  # convert to UTF-8 str
+    # Publish the message
+    future = publisher.publish(topic_path, base64_zip.encode("utf-8"))  # send back as bytes
+    print(":outbox_tray: Published message ID:", future.result())
+if __name__ == "__main__":
+    zip_folder(FOLDER_TO_ZIP, ZIP_NAME)
+    publish_base64_zip(ZIP_NAME, PROJECT_ID, TOPIC_ID)


### PR DESCRIPTION
**DRAFT PR**

What's new:
- Created an additional Dockerfile for .NET environment
- Created a bash script to run .NET tests and persist results to a file

What's refactored:
- Refactored SubmissionsController to dynamically build Dockerfile based on courseCode
- Cleaned up java Dockerfile
- Refactor UnzipSubmission to use dynamic file path at runtime
- Added courseCode to PubSubMessage POJO

.NET Dockerfile default versions:
- .NET: 8.0
- Gcloud: 456.0.0